### PR TITLE
fix(builder): `/opt` not created

### DIFF
--- a/target_builder/build_Windows-x86_64_rootfs
+++ b/target_builder/build_Windows-x86_64_rootfs
@@ -293,6 +293,7 @@ make_wsl_rootfs() {
 	mkdir -p "${ovmrootfs}/etc"
 	mkdir -p "${ovmrootfs}/home"
 	mkdir -p "${ovmrootfs}/root"
+	mkdir -p "${ovmrootfs}/opt"
 	mkdir -p "${ovmrootfs}/var/tmp"
 
 	cp "${BUSYBOX_BIN}" "${ovmrootfs}/usr/bin"


### PR DESCRIPTION
`/opt` was not created, causing `scripts/ovmd` to fail to move to `/opt` in build process