### PR TITLE
chore(scripts): logger_wrapper.sh redirect error and stdout to `tee-ovm`

### DIFF
--- a/scripts/logger_wrapper.sh
+++ b/scripts/logger_wrapper.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+# Wraps awk to redirect error and stdout to `tee-ovm`, 
+# This script works with openrc's supervise-daemon as a logger
+# - stdout to `/proc/${TEE_OVM_PID}/fd/1`
+# - stderr to `/proc/${TEE_OVM_PID}/fd/2`
+
+TEE_OVM_PID=$(busybox ps aux | grep -v grep | grep tee-ovm | xargs | busybox cut -d ' ' -f1)
+
+test -z ${TEE_OVM_PID} && {
+	echo "Error: ovm-tee not running !"
+	exit 100
+}
+
+logger_stdout() {
+ 	busybox	awk '{ print ENVIRON["RC_SVCNAME"] " " $0 }' >/proc/${TEE_OVM_PID}/fd/1
+}
+
+logger_stderr() {
+	busybox awk '{ print ENVIRON["RC_SVCNAME"] " " $0 }' >/proc/${TEE_OVM_PID}/fd/2
+}
+
+stdtype=${1}
+if [[ $stdtype = "stdout" ]]; then
+	logger_stdout
+else
+	logger_stderr
+fi


### PR DESCRIPTION
Open a shell session and wait for message arrive:
```sh
# stderr to /tmp/stderr_tee, stdout to /tmp/stdout_tee
$ /tmp/tee-ovm 1>/tmp/stdout_tee 2>/tmp/stderr_tee
```

open a shell session for writing message:
```sh
# write stderr message to tee-ovm
$ echo "stderr-message !" | ./logger_wrapper.sh stderr
# write stdout message to tee-ovm
$ echo "stdout-message !" | ./logger_wrapper.sh stdout
```