### PR TITLE
fix(scripts): `libs_packer.sh` do not package anything if miss any libraries

### DIFF
--- a/scripts/libs_packer.sh
+++ b/scripts/libs_packer.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-set -e 
+set -e
 # libs_packer.sh
 # Analyze dependencies and package dependencies and target ELF files
 
@@ -19,8 +19,8 @@ set -e
 
 SHORTOPTS="lpvh"
 LONGOPTS="list,pack,version,help"
-LIST=true
-PACK=false
+LIST_FLAG=true
+PACK_FLAG=false
 
 PARSED=$(getopt --options=$SHORTOPTS --longoptions=$LONGOPTS --name "$0" -- "$@")
 if [[ $? -ne 0 ]]; then
@@ -53,11 +53,11 @@ while true; do
 		shift
 		;;
 	-l | --list)
-		LIST=true
+		LIST_FLAG=true
 		shift
 		;;
 	-p | --pack)
-		PACK=true
+		PACK_FLAG=true
 		shift
 		;;
 	--)
@@ -78,16 +78,41 @@ ELF_LIST=()
 ELF_LIST+="${*}"
 for elf in $ELF_LIST; do
 	echo "Analyze ${elf}..."
+
+	# Find out the libraries required in ${elf} installed on system
 	LIBS=()
-	LIBS+=$(ldd ${elf} | grep -v linux-vdso | cut -d '>' -f2 | cut -d '(' -f1)
+	LIBS+=$(ldd ${elf} | grep -v linux-vdso | grep -v 'not found' | cut -d '>' -f2 | cut -d '(' -f1)
 	LIBS+=${elf}
-	
-	LIST=$(echo "${LIBS[@]}" | xargs)
-	for wb in $LIST; do
-		test ${PACK} = "true" && {
-			OUTPUT_DIR=${OUTPUT_DIR:="/tmp/"}
-			echo tar --dereference -rvf "${OUTPUT_DIR}/deps.tar" "${wb}"
-			tar --dereference -rvf "${OUTPUT_DIR}/deps.tar" "${wb}" > /dev/null 2>&1 
-		} || echo "  ${elf} require: ${wb}"
+
+	# Find out the libraries required in ${elf} but not installed on system
+	LIBS_NOT_INSTALLED=()
+	LIBS_NOT_INSTALLED=$(ldd ${elf} | grep -v linux-vdso | grep 'not found' | cut -d '=' -f1 | xargs)
+
+	for wb in ${LIBS_NOT_INSTALLED[*]}; do
+		test ${LIST_FLAG} = "true" && {
+			echo "  ${elf} require but NOT IN SYSTEM: ${wb}"
+		}
+	done
+
+	for wb in ${LIBS[*]}; do
+		test ${LIST_FLAG} = "true" && {
+			echo "  ${elf} require: ${wb}"
+		}
+	done
+
+	for wb in ${LIBS[*]}; do
+		# If any of the dependencies are not installed on the system, we shouldn't package anything at all.
+		test ${PACK_FLAG} = "true" && {
+			test -z "${LIBS_NOT_INSTALLED[*]}" && {
+				OUTPUT_DIR=${OUTPUT_DIR:="/tmp/"}
+				echo "  tar --dereference -rvf ${OUTPUT_DIR}/deps.tar ${wb}"
+				tar --dereference -rvf "${OUTPUT_DIR}/deps.tar" "${wb}" >/dev/null 2>&1
+
+			} || {
+				echo "  Error:"
+				echo "    ${LIBS_NOT_INSTALLED[*]} not installed on system, can not do pack"
+				exit 100
+			}
+		}
 	done
 done


### PR DESCRIPTION
If the target ELF's dependencies are not fully satisfied(meaning a library required but not installed to the system), `libs_packer.sh` should not pack anything because the dependencies are broken.

So this behavior is the expected behavior.

```bash
$ ./scripts/libs_packer.sh /tmp/openrc/usr/bin/rc-status  --list  -pack
Analyze /tmp/openrc/usr/bin/rc-status...
  /tmp/openrc/usr/bin/rc-status require but NOT IN SYSTEM: libeinfo.so.1 
  /tmp/openrc/usr/bin/rc-status require but NOT IN SYSTEM: librc.so.1
  /tmp/openrc/usr/bin/rc-status require: /lib/x86_64-linux-gnu/libc.so.6
  /tmp/openrc/usr/bin/rc-status require: /lib64/ld-linux-x86-64.so.2
  /tmp/openrc/usr/bin/rc-status require: /tmp/openrc/usr/bin/rc-status
  Error:
    libeinfo.so.1 librc.so.1 not installed on system, can not do pack <-- not pack anything
```