### PR TITLE
refactor(rootfs)!: disable podman cgroups in windows

### DIFF
--- a/layers/amd64_wsl2/etc/containers/containers.conf
+++ b/layers/amd64_wsl2/etc/containers/containers.conf
@@ -1,0 +1,13 @@
+[containers]
+cgroups = "disabled"
+default_sysctls = [
+  "net.ipv4.ping_group_range=0 0",
+]
+[secrets]
+[secrets.opts]
+[network]
+[engine]
+[engine.runtimes]
+[engine.volume_plugins]
+[machine]
+[farms]

--- a/make
+++ b/make
@@ -15,6 +15,9 @@ parse_profile() {
 	if [[ "${HOST_ARCH}" = 'aarch64' ]];then
 		HOST_ARCH=arm64
 	fi
+	if [[ "${HOST_ARCH}" = 'x86_64' ]];then
+		HOST_ARCH=amd64
+	fi
 
 	if [[ ! "${HOST_ARCH}" = "${TARGET_ARCH}" ]];then
 		echo "Error: HOST_ARCH must equal TARGET_ARCH"

--- a/target_builder/wsl2_amd64.sh
+++ b/target_builder/wsl2_amd64.sh
@@ -39,9 +39,7 @@ make_rootfs_disk(){
 # WSL2 no need build kernel
 kernel_builder(){
 	echo "Skip build kernel in ${profile_name}"
-	exit 0
 }
-
 
 # intended_func will be called in make, do not change this function name.
 intended_func() {
@@ -63,7 +61,7 @@ intended_func() {
 	if [[ -n ${rootfs_path} ]]; then
 		echo "($basename $0): Copy amd64_wsl2 layer"
 		set -xe
-		cp -rf ${layer}/*  ${rootfs_path}
+		sudo -E cp -rf ${layer}/*  ${rootfs_path}
 		set +xe
 	else
 		echo "Error: Env rootfs_path not defined by called script $0, stoped"


### PR DESCRIPTION
Due to the lack of [CDI device description](https://github.com/cncf-tags/container-device-interface/blob/main/SPEC.md), we currently disable "Cgroups" so that "nvidia-sim" and other programs that require nvidia drivers can call the Nvidia driver stack without crashing