### PR TITLE
fix(podman): socket hang up

### DIFF
--- a/layers/amd64_wsl2/opt/ovmd
+++ b/layers/amd64_wsl2/opt/ovmd
@@ -80,17 +80,20 @@ func_kill_ovmd() {
 }
 
 func_kill_service() {
+	openrc stop_all
+	while true; do
+		ps aux | grep -v grep | grep 'podman --log-level=' > /dev/null 
+		ret=$?
+		test $ret -eq 0 && echo "Killing podman api..." || {
+			echo "Podman api stoped"
+			break
+		}
+	done
+
 	PODMAN_IGNORE_CGROUPSV1_WARNING=1 podman stop -a
 	ret=$?
 	test $ret -eq 0 && echo "All containers stoped" || {
 		echo "Containers stop failed"
-		exit 100
-	}
-
-	openrc stop_all
-	ret=$?
-	test $ret -eq 0 && echo "All openrc services stoped" || {
-		echo "Some openrc service stop failed"
 		exit 100
 	}
 }


### PR DESCRIPTION
Stopping the container takes some time. If we do not kill the podman API server first, the upper-layer application will mistakenly assume that the API service is ready, leading to socket hang up issues during subsequent operations.

Therefore, we need to kill the podman API server first and then stop the container to avoid this problem.
In the future, we will use an event notification solution to completely avoid this issue.