### PR TITLE
chore(dockerfile): add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:noble
+
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
+WORKDIR /root/MkRoot
+
+COPY ./ /root/MkRoot/
+RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+
+CMD ["./make", "macos_arm64"]
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@
 - `SKIP_BUILD_PROOT=true`: Skip build [proot](https://github.com/proot-me/proot)
 - `SKIP_APT_GET_INSTALL=true`: Skip `apt update && apt install -y required package`
 - `VM_PROVIDER=qemu`: using qemu as vm provider
+
+
+## Dockerfile
+```bash
+docker build -t ubuntu-noble-build .
+# Only if you need proxy
+docker build --build-arg http_proxy=http://192.168.1.250:2020 --build-arg https_proxy=http://192.168.1.250:2020 -t ubuntu-noble-build .
+```


### PR DESCRIPTION
# Using dockerfile build bootable-arm64.img

Build `bootable-arm64.img` need `kpartx` device mapping which requires root privileges :
```
$ docker build -t ubuntu-noble-build .

$ docker run -it --privileged -v ./output:/root/MkRoot/output ubuntu-noble-build
```
